### PR TITLE
Remove 'First' from keyvault-certs bullet

### DIFF
--- a/releases/2019-09-17/2019-09-17-python-preview3.md
+++ b/releases/2019-09-17/2019-09-17-python-preview3.md
@@ -54,7 +54,7 @@ Detailed change logs are linked to in the Quick Links below. Here are some criti
 
 ### Key Vault
 
-- First release of `azure-keyvault-certificates` supporting the certificates API
+- Release of `azure-keyvault-certificates` supporting the certificates API
 - `CryptographyClient` can perform encrypt/verify/wrap operations locally
 
 ### Storage


### PR DESCRIPTION
... because it's versioned b3, not b1, and so could confuse.